### PR TITLE
Polish up the driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,6 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
-Usage Example
-=============
-
-yes
-
 Contributing
 ============
 

--- a/adafruit_as726x.py
+++ b/adafruit_as726x.py
@@ -28,130 +28,130 @@ Driver for the AS726x spectral sensors
 * Author(s): Dean Miller
 """
 
-# imports
+import time
+from adafruit_bus_device.i2c_device import I2CDevice
+from micropython import const
+
+try:
+    import struct
+except ImportError:
+    import ustruct as struct
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_AS726x.git"
 
-import time
-from adafruit_bus_device.i2c_device import I2CDevice
-from micropython import const
-import ustruct
+_AS726X_ADDRESS = const(0x49)
 
-AS726X_ADDRESS = const(0x49)
-
-AS726X_HW_VERSION = const(0x00)
-AS726X_FW_VERSION = const(0x02)
-AS726X_CONTROL_SETUP = const(0x04)
-AS726X_INT_T = const(0x05)
-AS726X_DEVICE_TEMP = const(0x06)
-AS726X_LED_CONTROL = const(0x07)
+_AS726X_HW_VERSION = const(0x00)
+_AS726X_FW_VERSION = const(0x02)
+_AS726X_CONTROL_SETUP = const(0x04)
+_AS726X_INT_T = const(0x05)
+_AS726X_DEVICE_TEMP = const(0x06)
+_AS726X_LED_CONTROL = const(0x07)
 
 #for reading sensor data
-AS7262_V_HIGH = const(0x08)
-AS7262_V_LOW = const(0x09)
-AS7262_B_HIGH = const(0x0A)
-AS7262_B_LOW = const(0x0B)
-AS7262_G_HIGH = const(0x0C)
-AS7262_G_LOW = const(0x0D)
-AS7262_Y_HIGH = const(0x0E)
-AS7262_Y_LOW = const(0x0F)
-AS7262_O_HIGH = const(0x10)
-AS7262_O_LOW = const(0x11)
-AS7262_R_HIGH = const(0x12)
-AS7262_R_LOW = const(0x13)
+_AS7262_V_HIGH = const(0x08)
+_AS7262_V_LOW = const(0x09)
+_AS7262_B_HIGH = const(0x0A)
+_AS7262_B_LOW = const(0x0B)
+_AS7262_G_HIGH = const(0x0C)
+_AS7262_G_LOW = const(0x0D)
+_AS7262_Y_HIGH = const(0x0E)
+_AS7262_Y_LOW = const(0x0F)
+_AS7262_O_HIGH = const(0x10)
+_AS7262_O_LOW = const(0x11)
+_AS7262_R_HIGH = const(0x12)
+_AS7262_R_LOW = const(0x13)
 
-AS7262_V_CAL = const(0x14)
-AS7262_B_CAL = const(0x18)
-AS7262_G_CAL = const(0x1C)
-AS7262_Y_CAL = const(0x20)
-AS7262_O_CAL = const(0x24)
-AS7262_R_CAL = const(0x28)
+_AS7262_V_CAL = const(0x14)
+_AS7262_B_CAL = const(0x18)
+_AS7262_G_CAL = const(0x1C)
+_AS7262_Y_CAL = const(0x20)
+_AS7262_O_CAL = const(0x24)
+_AS7262_R_CAL = const(0x28)
 
 #hardware registers
-AS726X_SLAVE_STATUS_REG = const(0x00)
-AS726X_SLAVE_WRITE_REG = const(0x01)
-AS726X_SLAVE_READ_REG = const(0x02)
-AS726X_SLAVE_TX_VALID = const(0x02)
-AS726X_SLAVE_RX_VALID = const(0x01)
+_AS726X_SLAVE_STATUS_REG = const(0x00)
+_AS726X_SLAVE_WRITE_REG = const(0x01)
+_AS726X_SLAVE_READ_REG = const(0x02)
+_AS726X_SLAVE_TX_VALID = const(0x02)
+_AS726X_SLAVE_RX_VALID = const(0x01)
 
-AS7262_VIOLET = const(0x08)
-AS7262_BLUE = const(0x0A)
-AS7262_GREEN = const(0x0C)
-AS7262_YELLOW = const(0x0E)
-AS7262_ORANGE = const(0x10)
-AS7262_RED = const(0x12)
-AS7262_VIOLET_CALIBRATED = const(0x14)
-AS7262_BLUE_CALIBRATED = const(0x18)
-AS7262_GREEN_CALIBRATED = const(0x1C)
-AS7262_YELLOW_CALIBRATED = const(0x20)
-AS7262_ORANGE_CALIBRATED = const(0x24)
-AS7262_RED_CALIBRATED = const(0x28)
+_AS7262_VIOLET = const(0x08)
+_AS7262_BLUE = const(0x0A)
+_AS7262_GREEN = const(0x0C)
+_AS7262_YELLOW = const(0x0E)
+_AS7262_ORANGE = const(0x10)
+_AS7262_RED = const(0x12)
+_AS7262_VIOLET_CALIBRATED = const(0x14)
+_AS7262_BLUE_CALIBRATED = const(0x18)
+_AS7262_GREEN_CALIBRATED = const(0x1C)
+_AS7262_YELLOW_CALIBRATED = const(0x20)
+_AS7262_ORANGE_CALIBRATED = const(0x24)
+_AS7262_RED_CALIBRATED = const(0x28)
 
-AS726X_NUM_CHANNELS = const(6)
+_AS726X_NUM_CHANNELS = const(6)
 
 #pylint: disable=too-many-instance-attributes
 #pylint: disable=too-many-public-methods
 class Adafruit_AS726x(object):
-    """Driver for the AS726x spectral sensor."""
+    """AS726x spectral sensor.
+
+       :param ~busio.I2C i2c_bus: The I2C bus connected to the sensor
+       """
 
     MODE_0 = 0b00
+    """Continuously gather samples of violet, blue, green and yellow. Orange and red are skipped
+       and read zero."""
+
     MODE_1 = 0b01
+    """Continuously gather samples of green, yellow, orange and red. Violet and blue are skipped
+       and read zero."""
+
     MODE_2 = 0b10 #default
+    """Continuously gather samples of all colors"""
+
     ONE_SHOT = 0b11
+    """Gather a single sample of all colors and then stop"""
 
-    GAIN_1X = 0b00 #default
-    GAIN_3X7 = 0b01
-    GAIN_16X = 0b10
-    GAIN_64X = 0b11
+    GAIN = (1, 3.7, 16, 64)
 
-    LIMIT_1MA = 0b00 #default
-    LIMIT_2MA = 0b01
-    LIMIT_4MA = 0b10
-    LIMIT_8MA = 0b11
+    INDICATOR_CURRENT_LIMITS = (1, 2, 4, 8)
 
-    LIMIT_12MA5 = 0b00 #default
-    LIMIT_25MA = 0b01
-    LIMIT_50MA = 0b10
-    LIMIT_100MA = 0b11
+    DRIVER_CURRENT_LIMITS = (12.5, 25, 50, 100)
 
-    def __init__(self, i2c, *, address=AS726X_ADDRESS):
-
+    def __init__(self, i2c_bus):
         self._driver_led = False
         self._indicator_led = False
-        self._driver_led_current = self.LIMIT_12MA5
-        self._indicator_led_current = self.LIMIT_1MA
-        self._conversion_mode = self.MODE_0
+        self._driver_led_current = Adafruit_AS726x.DRIVER_CURRENT_LIMITS.index(12.5)
+        self._indicator_led_current = Adafruit_AS726x.INDICATOR_CURRENT_LIMITS.index(0)
+        self._conversion_mode = Adafruit_AS726x.MODE_2
         self._integration_time = 0
-        self._gain = self.GAIN_1X
+        self._gain = Adafruit_AS726x.GAIN.index(1)
         self.buf2 = bytearray(2)
 
-        self.i2c_device = I2CDevice(i2c, address)
+        self.i2c_device = I2CDevice(i2c_bus, _AS726X_ADDRESS)
 
         #reset device
-        self._virtual_write(AS726X_CONTROL_SETUP, 0x80)
+        self._virtual_write(_AS726X_CONTROL_SETUP, 0x80)
 
         #wait for it to boot up
         time.sleep(1)
 
         #try to read the version reg to make sure we can connect
-        version = self._virtual_read(AS726X_HW_VERSION)
+        version = self._virtual_read(_AS726X_HW_VERSION)
 
         #TODO: add support for other devices
         if version != 0x40:
             raise ValueError("device could not be reached or this device is not supported!")
 
         self.integration_time = 140
-
-        self.gain = self.GAIN_64X
-
-        #self.conversion_mode = AS726x_ONE_SHOT
+        self.conversion_mode = Adafruit_AS726x.MODE_2
+        self.gain = 64
 
     @property
     def driver_led(self):
-        """Get and set the state of the driver LED. Boolean value that will
-        turn on the LED with a value of True and disable with a value of False.
-        """
+        """True when the driver LED is on. False otherwise."""
         return self._driver_led
 
     @driver_led.setter
@@ -160,15 +160,13 @@ class Adafruit_AS726x(object):
         if self._driver_led == val:
             return
         self._driver_led = val
-        enable = self._virtual_read(AS726X_LED_CONTROL)
-        enable &= ~(val << 3)
-        self._virtual_write(AS726X_LED_CONTROL, enable | (val << 3))
+        enable = self._virtual_read(_AS726X_LED_CONTROL)
+        enable &= ~(0x1 << 3)
+        self._virtual_write(_AS726X_LED_CONTROL, enable | (val << 3))
 
     @property
     def indicator_led(self):
-        """Get and set the state of the indicator LED. Boolean value that will
-        turn on the LED with a value of True and disable with a value of False.
-        """
+        """True when the indicator LED is on. False otherwise."""
         return self._indicator_led
 
     @indicator_led.setter
@@ -177,45 +175,62 @@ class Adafruit_AS726x(object):
         if self._indicator_led == val:
             return
         self._indicator_led = val
-        enable = self._virtual_read(AS726X_LED_CONTROL)
-        enable &= ~(val)
-        self._virtual_write(AS726X_LED_CONTROL, enable | val)
+        enable = self._virtual_read(_AS726X_LED_CONTROL)
+        enable &= ~(0x1)
+        self._virtual_write(_AS726X_LED_CONTROL, enable | val)
 
     @property
     def driver_led_current(self):
-        """Get and set the current limit for the driver LED"""
+        """The current limit for the driver LED in milliamps. One of:
+
+           - 12.5 mA
+           - 25 mA
+           - 50 mA
+           - 100 mA"""
         return self._driver_led_current
 
     @driver_led_current.setter
     def driver_led_current(self, val):
-        val = int(val)
-        assert self.LIMIT_12MA5 <= val <= self.LIMIT_100MA
+        if val not in Adafruit_AS726x.DRIVER_CURRENT_LIMITS:
+            raise ValueError("Must be 12.5, 25, 50 or 100")
         if self._driver_led_current == val:
             return
         self._driver_led_current = val
-        state = self._virtual_read(AS726X_LED_CONTROL)
-        state &= ~(val << 4)
-        self._virtual_write(AS726X_LED_CONTROL, state | (val << 4))
+        state = self._virtual_read(_AS726X_LED_CONTROL)
+        state &= ~(0x3 << 4)
+        state = state | (Adafruit_AS726x.DRIVER_CURRENT_LIMITS.index(val) << 4)
+        self._virtual_write(_AS726X_LED_CONTROL, state)
 
     @property
     def indicator_led_current(self):
-        """Get and set the current limit for the indicator LED"""
+        """The current limit for the indicator LED in milliamps. One of:
+
+           - 1 mA
+           - 2 mA
+           - 4 mA
+           - 8 mA"""
         return self._indicator_led_current
 
     @indicator_led_current.setter
     def indicator_led_current(self, val):
-        val = int(val)
-        assert self.LIMIT_1MA <= val <= self.LIMIT_8MA
+        if val not in Adafruit_AS726x.INDICATOR_CURRENT_LIMITS:
+            raise ValueError("Must be 1, 2, 4 or 8")
         if self._indicator_led_current == val:
             return
         self._indicator_led_current = val
-        state = self._virtual_read(AS726X_LED_CONTROL)
-        state &= ~(val << 1)
-        self._virtual_write(AS726X_LED_CONTROL, state | (val << 1))
+        state = self._virtual_read(_AS726X_LED_CONTROL)
+        state &= ~(0x3 << 1)
+        state = state | (Adafruit_AS726x.INDICATOR_CURRENT_LIMITS.index(val) << 4)
+        self._virtual_write(_AS726X_LED_CONTROL, state)
 
     @property
     def conversion_mode(self):
-        """Get and set the conversion mode"""
+        """The conversion mode. One of:
+
+           - `MODE_0`
+           - `MODE_1`
+           - `MODE_2`
+           - `ONE_SHOT`"""
         return self._conversion_mode
 
     @conversion_mode.setter
@@ -225,46 +240,50 @@ class Adafruit_AS726x(object):
         if self._conversion_mode == val:
             return
         self._conversion_mode = val
-        state = self._virtual_read(AS726X_CONTROL_SETUP)
+        state = self._virtual_read(_AS726X_CONTROL_SETUP)
         state &= ~(val << 2)
-        self._virtual_write(AS726X_CONTROL_SETUP, state | (val << 2))
+        self._virtual_write(_AS726X_CONTROL_SETUP, state | (val << 2))
 
     @property
     def gain(self):
-        """Get and set the gain for the sensor"""
+        """The gain for the sensor"""
         return self._gain
 
     @gain.setter
     def gain(self, val):
-        val = int(val)
-        assert self.GAIN_1X <= val <= self.GAIN_64X
+        if val not in Adafruit_AS726x.GAIN:
+            raise ValueError("Must be 1, 3.7, 16 or 64")
         if self._gain == val:
             return
         self._gain = val
-        state = self._virtual_read(AS726X_CONTROL_SETUP)
-        state &= ~(val << 4)
-        self._virtual_write(AS726X_CONTROL_SETUP, state | (val << 4))
+        state = self._virtual_read(_AS726X_CONTROL_SETUP)
+        state &= ~(0x3 << 4)
+        state |= (Adafruit_AS726x.GAIN.index(val) << 4)
+        self._virtual_write(_AS726X_CONTROL_SETUP, state)
 
     @property
     def integration_time(self):
-        """Get and set the integration time in milliseconds for the sensor"""
+        """The integration time in milliseconds between 2.8 and 714 ms"""
         return self._integration_time
 
     @integration_time.setter
     def integration_time(self, val):
-        """Get and set integration time for the sensor"""
         val = int(val)
-        assert 0 <= val <= 714
+        if not 2.8 <= val <= 714:
+            raise ValueError("Out of supported range 2.8 - 714 ms")
         if self._integration_time == val:
             return
         self._integration_time = val
-        self._virtual_write(AS726X_INT_T, int(val/2.8))
+        self._virtual_write(_AS726X_INT_T, int(val/2.8))
 
     def start_measurement(self):
-        """Begin a measurement. This will set the device to One Shot mode"""
-        state = self._virtual_read(AS726X_CONTROL_SETUP)
+        """Begin a measurement.
+
+           This will set the device to One Shot mode and values will not change after `data_ready`
+           until `start_measurement` is called again or the `conversion_mode` is changed."""
+        state = self._virtual_read(_AS726X_CONTROL_SETUP)
         state &= ~(0x02)
-        self._virtual_write(AS726X_CONTROL_SETUP, state)
+        self._virtual_write(_AS726X_CONTROL_SETUP, state)
 
         self.conversion_mode = self.ONE_SHOT
 
@@ -279,77 +298,77 @@ class Adafruit_AS726x(object):
         val[1] = self._virtual_read(channel + 1)
         val[2] = self._virtual_read(channel + 2)
         val[3] = self._virtual_read(channel + 3)
-        return ustruct.unpack('!f', val)[0]
+        return struct.unpack('!f', val)[0]
 
     @property
     def data_ready(self):
-        """Returns True if the sensor has data ready to be read, False otherwise"""
-        return (self._virtual_read(AS726X_CONTROL_SETUP) >> 1) & 0x01
+        """True if the sensor has data ready to be read, False otherwise"""
+        return (self._virtual_read(_AS726X_CONTROL_SETUP) >> 1) & 0x01
 
     @property
     def temperature(self):
-        """Get the temperature of the device in Centigrade"""
-        return self._virtual_read(AS726X_DEVICE_TEMP)
+        """The temperature of the device in Celsius"""
+        return self._virtual_read(_AS726X_DEVICE_TEMP)
 
     @property
     def violet(self):
-        """raw violet"""
-        return self.read_channel(AS7262_VIOLET)
+        """Calibrated violet (450nm) value"""
+        return self.read_calibrated_value(_AS7262_VIOLET_CALIBRATED)
 
     @property
     def blue(self):
-        """raw blue"""
-        return self.read_channel(AS7262_BLUE)
+        """Calibrated blue (500nm) value"""
+        return self.read_calibrated_value(_AS7262_BLUE_CALIBRATED)
 
     @property
     def green(self):
-        """raw green"""
-        return self.read_channel(AS7262_GREEN)
+        """Calibrated green (550nm) value"""
+        return self.read_calibrated_value(_AS7262_GREEN_CALIBRATED)
 
     @property
     def yellow(self):
-        """raw yellow"""
-        return self.read_channel(AS7262_YELLOW)
+        """Calibrated yellow (570nm) value"""
+        return self.read_calibrated_value(_AS7262_YELLOW_CALIBRATED)
 
     @property
     def orange(self):
-        """raw orange"""
-        return self.read_channel(AS7262_ORANGE)
+        """Calibrated orange (600nm) value"""
+        return self.read_calibrated_value(_AS7262_ORANGE_CALIBRATED)
 
     @property
     def red(self):
-        """raw red"""
-        return self.read_channel(AS7262_RED)
+        """Calibrated red (650nm) value"""
+        return self.read_calibrated_value(_AS7262_RED_CALIBRATED)
 
     @property
-    def violet_calibrated(self):
-        """calibrated violet"""
-        return self.read_calibrated_value(AS7262_VIOLET_CALIBRATED)
+    def raw_violet(self):
+        """Raw violet (450nm) 16-bit value"""
+        return self.read_channel(_AS7262_VIOLET)
 
     @property
-    def blue_calibrated(self):
-        """calibrated blue"""
-        return self.read_calibrated_value(AS7262_BLUE_CALIBRATED)
+    def raw_blue(self):
+        """Raw blue (500nm) 16-bit value"""
+        return self.read_channel(_AS7262_BLUE)
 
     @property
-    def green_calibrated(self):
-        """calibrated green"""
-        return self.read_calibrated_value(AS7262_GREEN_CALIBRATED)
+    def raw_green(self):
+        """Raw green (550nm) 16-bit value"""
+        return self.read_channel(_AS7262_GREEN)
 
     @property
-    def yellow_calibrated(self):
-        """calibrated yellow"""
-        return self.read_calibrated_value(AS7262_YELLOW_CALIBRATED)
+    def raw_yellow(self):
+        """Raw yellow (570nm) 16-bit value"""
+        return self.read_channel(_AS7262_YELLOW)
 
     @property
-    def orange_calibrated(self):
-        """calibrated orange"""
-        return self.read_calibrated_value(AS7262_ORANGE_CALIBRATED)
+    def raw_orange(self):
+        """Raw orange (600nm) 16-bit value"""
+        return self.read_channel(_AS7262_ORANGE)
 
     @property
-    def red_calibrated(self):
-        """calibrated red"""
-        return self.read_calibrated_value(AS7262_RED_CALIBRATED)
+    def raw_red(self):
+        """Raw red (650nm) 16-bit value"""
+        return self.read_channel(_AS7262_RED)
 
     def _read_u8(self, command):
         """read a single byte from a specified register"""
@@ -370,42 +389,41 @@ class Adafruit_AS726x(object):
 
     def _virtual_read(self, addr):
         """read a virtual register"""
-        while 1:
+        while True:
             # Read slave I2C status to see if the read buffer is ready.
-            status = self._read_u8(AS726X_SLAVE_STATUS_REG)
-            if (status & AS726X_SLAVE_TX_VALID) == 0:
+            status = self._read_u8(_AS726X_SLAVE_STATUS_REG)
+            if (status & _AS726X_SLAVE_TX_VALID) == 0:
                 # No inbound TX pending at slave. Okay to write now.
                 break
         # Send the virtual register address (setting bit 7 to indicate a pending write).
-        self.__write_u8(AS726X_SLAVE_WRITE_REG, addr)
-        while 1:
+        self.__write_u8(_AS726X_SLAVE_WRITE_REG, addr)
+        while True:
             # Read the slave I2C status to see if our read data is available.
-            status = self._read_u8(AS726X_SLAVE_STATUS_REG)
-            if (status & AS726X_SLAVE_RX_VALID) != 0:
+            status = self._read_u8(_AS726X_SLAVE_STATUS_REG)
+            if (status & _AS726X_SLAVE_RX_VALID) != 0:
                 # Read data is ready.
                 break
         # Read the data to complete the operation.
-        data = self._read_u8(AS726X_SLAVE_READ_REG)
+        data = self._read_u8(_AS726X_SLAVE_READ_REG)
         return data
-
 
     def _virtual_write(self, addr, value):
         """write a virtual register"""
-        while 1:
+        while True:
             # Read slave I2C status to see if the write buffer is ready.
-            status = self._read_u8(AS726X_SLAVE_STATUS_REG)
-            if (status & AS726X_SLAVE_TX_VALID) == 0:
+            status = self._read_u8(_AS726X_SLAVE_STATUS_REG)
+            if (status & _AS726X_SLAVE_TX_VALID) == 0:
                 break # No inbound TX pending at slave. Okay to write now.
         # Send the virtual register address (setting bit 7 to indicate a pending write).
-        self.__write_u8(AS726X_SLAVE_WRITE_REG, (addr | 0x80))
-        while 1:
+        self.__write_u8(_AS726X_SLAVE_WRITE_REG, (addr | 0x80))
+        while True:
             # Read the slave I2C status to see if the write buffer is ready.
-            status = self._read_u8(AS726X_SLAVE_STATUS_REG)
-            if (status & AS726X_SLAVE_TX_VALID) == 0:
+            status = self._read_u8(_AS726X_SLAVE_STATUS_REG)
+            if (status & _AS726X_SLAVE_TX_VALID) == 0:
                 break # No inbound TX pending at slave. Okay to write data now.
 
         # Send the data to complete the operation.
-        self.__write_u8(AS726X_SLAVE_WRITE_REG, value)
+        self.__write_u8(_AS726X_SLAVE_WRITE_REG, value)
 
 
 #pylint: enable=too-many-instance-attributes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,8 @@ extensions = [
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = ["digitalio", "busio", "adafruit_bus_device", "micropython", "ustruct"]
 
+autodoc_member_order = 'bysource'
+
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'BusDevice': ('https://circuitpython.readthedocs.io/projects/bus_device/en/latest/', None),'Register': ('https://circuitpython.readthedocs.io/projects/register/en/latest/', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}
 
 # Add any paths that contain templates here, relative to this directory.

--- a/examples/as726x_simpletest.py
+++ b/examples/as726x_simpletest.py
@@ -20,18 +20,18 @@ sensor = Adafruit_AS726x(i2c)
 
 sensor.conversion_mode = sensor.MODE_2
 
-while 1:
-    #wait for data to be ready
+while True:
+    # Wait for data to be ready
     while not sensor.data_ready:
         time.sleep(.1)
 
     #plot plot the data
     print("\n")
-    print("V: " + graph_map(sensor.violet_calibrated)*'=')
-    print("B: " + graph_map(sensor.blue_calibrated)*'=')
-    print("G: " + graph_map(sensor.green_calibrated)*'=')
-    print("Y: " + graph_map(sensor.yellow_calibrated)*'=')
-    print("O: " + graph_map(sensor.orange_calibrated)*'=')
-    print("R: " + graph_map(sensor.red_calibrated)*'=')
+    print("V: " + graph_map(sensor.violet)*'=')
+    print("B: " + graph_map(sensor.blue)*'=')
+    print("G: " + graph_map(sensor.green)*'=')
+    print("Y: " + graph_map(sensor.yellow)*'=')
+    print("O: " + graph_map(sensor.orange)*'=')
+    print("R: " + graph_map(sensor.red)*'=')
 
     time.sleep(1)


### PR DESCRIPTION
* Add _ prefix to constants so they are compiled in by mpy-cross.
* Make violet and similar the calibrated value. Raw values are raw_*
* Replace while 1s with while Trues.
* Change numeric properties to tuple of valid values so values are simple
  data types (int and float) rather than ENUMs.
* Add mode documentation so the datasheet isn't needed to understand them.