### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_AS726x.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_AS726x
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_AS726x.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_AS726x
     :alt: Build Status
 
 Driver for the AS726x spectral sensors


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.