### PR TITLE
Add UART support

### DIFF
--- a/adafruit_as726x.py
+++ b/adafruit_as726x.py
@@ -113,6 +113,7 @@ _COLOR_REGS_CALIBRATED = (
 # pylint: disable=too-many-public-methods
 # pylint: disable=invalid-name
 # pylint: disable=no-else-return
+# pylint: disable=inconsistent-return-statements
 
 
 class AS726x:
@@ -493,7 +494,6 @@ class AS726x_UART(AS726x):
         return None
 
     def _virtual_read(self, addr):
-        # pylint: disable=inconsistent-return-statements
         if addr == _AS726X_HW_VERSION:
             # just return what is expected
             return 0x40
@@ -544,3 +544,4 @@ class AS726x_UART(AS726x):
 # pylint: enable=too-many-public-methods
 # pylint: enable=invalid-name
 # pylint: enable=no-else-return
+# pylint: enable=inconsistent-return-statements

--- a/adafruit_as726x.py
+++ b/adafruit_as726x.py
@@ -114,6 +114,7 @@ _COLOR_REGS_CALIBRATED = (
 # pylint: disable=invalid-name
 # pylint: disable=no-else-return
 
+
 class AS726x:
     """AS726x spectral sensor base class.
 

--- a/adafruit_as726x.py
+++ b/adafruit_as726x.py
@@ -111,7 +111,8 @@ _COLOR_REGS_CALIBRATED = (
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-public-methods
-
+# pylint: disable=invalid-name
+# pylint: disable=no-else-return
 
 class AS726x:
     """AS726x spectral sensor base class.
@@ -488,8 +489,7 @@ class AS726x_UART(AS726x):
         if self._uart.in_waiting:
             resp = self._uart.read(self._uart.in_waiting)
             return resp.rstrip(b" OK\n")
-        else:
-            return None
+        return None
 
     def _virtual_read(self, addr):
         if addr == _AS726X_HW_VERSION:
@@ -540,3 +540,5 @@ class AS726x_UART(AS726x):
 
 # pylint: enable=too-many-instance-attributes
 # pylint: enable=too-many-public-methods
+# pylint: enable=invalid-name
+# pylint: enable=no-else-return

--- a/adafruit_as726x.py
+++ b/adafruit_as726x.py
@@ -493,6 +493,7 @@ class AS726x_UART(AS726x):
         return None
 
     def _virtual_read(self, addr):
+        # pylint: disable=inconsistent-return-statements
         if addr == _AS726X_HW_VERSION:
             # just return what is expected
             return 0x40

--- a/examples/as726x_simpletest.py
+++ b/examples/as726x_simpletest.py
@@ -3,7 +3,10 @@ import time
 import board
 import busio
 
-from adafruit_as726x import Adafruit_AS726x
+# for I2C use:
+from adafruit_as726x import AS726x_I2C
+# for UART use:
+#from adafruit_as726x import AS726x_UART
 
 # maximum value for sensor reading
 max_val = 16000
@@ -16,9 +19,13 @@ def graph_map(x):
     return min(int(x * max_graph / max_val), max_graph)
 
 
-# Initialize I2C bus and sensor.
+# for I2C use:
 i2c = busio.I2C(board.SCL, board.SDA)
-sensor = Adafruit_AS726x(i2c)
+sensor = AS726x_I2C(i2c)
+
+# for UART use:
+#uart = busio.UART(board.TX, board.RX)
+#sensor = AS726x_UART(uart)
 
 sensor.conversion_mode = sensor.MODE_2
 

--- a/examples/as726x_simpletest.py
+++ b/examples/as726x_simpletest.py
@@ -5,8 +5,9 @@ import busio
 
 # for I2C use:
 from adafruit_as726x import AS726x_I2C
+
 # for UART use:
-#from adafruit_as726x import AS726x_UART
+# from adafruit_as726x import AS726x_UART
 
 # maximum value for sensor reading
 max_val = 16000
@@ -24,8 +25,8 @@ i2c = busio.I2C(board.SCL, board.SDA)
 sensor = AS726x_I2C(i2c)
 
 # for UART use:
-#uart = busio.UART(board.TX, board.RX)
-#sensor = AS726x_UART(uart)
+# uart = busio.UART(board.TX, board.RX)
+# sensor = AS726x_UART(uart)
 
 sensor.conversion_mode = sensor.MODE_2
 


### PR DESCRIPTION
For #8  

**BREAKING CHANGE**

- Adds UART support
- Classes refactored into base and I2C/UART specific subs
- Classes renamed to remove leading `Adafruit_`
- Example updated

Tested with Itsy M4.

![itsy_test](https://user-images.githubusercontent.com/8755041/79643943-7e0c5a80-815a-11ea-8c61-aaa47e790027.jpg)

```python
Adafruit CircuitPython 5.1.0 on 2020-04-02; Adafruit ItsyBitsy M4 Express with samd51g19
>>> import as726x_simpletest


V: 
B: =
G: ========
Y: =====
O: ==============
R: ===
```